### PR TITLE
docs: use consistent capitalization when referring to I2P

### DIFF
--- a/docs/ANONYMITY_NETWORKS.md
+++ b/docs/ANONYMITY_NETWORKS.md
@@ -86,7 +86,7 @@ otherwise the peer will not be notified of the peer address by the proxy.
 
 An anonymity network can be configured to forward incoming connections to a
 `monerod` RPC port - which is independent from the configuration for incoming
-P2P anonymity connections. The anonymity network (Tor/i2p) is
+P2P anonymity connections. The anonymity network (Tor/I2P) is
 [configured in the same manner](#configuration), except the localhost port
 must be the RPC port (typically 18081 for mainnet) instead of the p2p port:
 
@@ -95,16 +95,16 @@ HiddenServiceDir /var/lib/tor/data/monero
 HiddenServicePort 18081 127.0.0.1:18081
 ```
 
-Then the wallet will be configured to use a Tor/i2p address:
+Then the wallet will be configured to use a Tor/I2P address:
 ```
 --proxy 127.0.0.1:9050
 --daemon-address rveahdfho7wo4b2m.onion
 ```
 
 The proxy must match the address type - a Tor proxy will not work properly with
-i2p addresses, etc.
+I2P addresses, etc.
 
-i2p and onion addresses provide the information necessary to authenticate and
+I2P and onion addresses provide the information necessary to authenticate and
 encrypt the connection from end-to-end. If desired, SSL can also be applied to
 the connection with `--daemon-address https://rveahdfho7wo4b2m.onion` which
 requires a server certificate that is signed by a "root" certificate on the

--- a/docs/LEVIN_PROTOCOL.md
+++ b/docs/LEVIN_PROTOCOL.md
@@ -118,7 +118,7 @@ that was sent in the request message. The `Return Code` is specific to the
 `Command` being issued (see [commands])(#commands)).
 
 ### Fragmented
-Fragmented messages were introduced for the "white noise" feature for i2p/tor.
+Fragmented messages were introduced for the "white noise" feature for I2P/Tor.
 A transaction can be sent in fragments to conceal when "real" data is being
 sent instead of dummy messages. Only one fragmented message can be sent at a
 time, and bits `B` and `E` are never set at the same time


### PR DESCRIPTION
Since most of the time the docs refer to I2P as such (uppercase), and since that's the way I2P refers to it throughout [their site](https://geti2p.net/en/), this PR changes the (lowercase) 'i2p' occurences to 'I2P.'